### PR TITLE
fix(mongo/schema) added createdTimestamp input

### DIFF
--- a/controllers/thought.js
+++ b/controllers/thought.js
@@ -22,10 +22,12 @@ exports.addThought = async(req,res) => {
         error:[error.details[0]]
     })
     
+    const timestamp = Math.floor(new Date()/1000);
     const thoughtObj = new Thought({
         thought: req.body.thought,
         author: req.body.author,
-        url: req.body.url
+        url: req.body.url,
+        createdTimestamp: timestamp
     })
 
     try{

--- a/controllers/thought.js
+++ b/controllers/thought.js
@@ -22,12 +22,10 @@ exports.addThought = async(req,res) => {
         error:[error.details[0]]
     })
     
-    const timestamp = Math.floor(new Date()/1000);
     const thoughtObj = new Thought({
         thought: req.body.thought,
         author: req.body.author,
-        url: req.body.url,
-        createdTimestamp: timestamp
+        url: req.body.url
     })
 
     try{

--- a/models/Thought.js
+++ b/models/Thought.js
@@ -1,9 +1,6 @@
 const mongoose = require('mongoose');
 
 const thoughtSchema = new mongoose.Schema({
-    name:{
-        type:String
-    },
     thought:{
         type:String
     },
@@ -12,6 +9,9 @@ const thoughtSchema = new mongoose.Schema({
     },
     url:{
         type:String
+    },
+    createdTimestamp:{
+        type:Number
     }
     
 });


### PR DESCRIPTION
The createdTimestamp input was missing in the mongo Thought schema.
In order to fulfill the createdTimestamp value, a variable called timestamp was added to the controller, automatically serving as input.